### PR TITLE
add dnsmasq exporter target

### DIFF
--- a/configs/system/dnsmasq.conf
+++ b/configs/system/dnsmasq.conf
@@ -4,7 +4,7 @@ interface=wlan0 # Interface to lisen for DHCP Requests
   dhcp-range=10.1.1.10,10.1.1.240,255.255.255.0,24h # Range of IPs to assign and TTL
 
 domain=pilink # Domain Name for Pi-Link network
-address=/hub.pilink/10.1.1.1  # The aliases for Pi
+address=/ubuntu/10.1.1.1  # The aliases for Pi
 
 # Cloudflares's nameservers
 server=1.1.1.1

--- a/configs/system/dnsmasq.conf
+++ b/configs/system/dnsmasq.conf
@@ -1,5 +1,11 @@
+listen-address=::1,127.0.0.1,10.1.1.1,127.0.0.53
+
 interface=wlan0 # Interface to lisen for DHCP Requests
   dhcp-range=10.1.1.10,10.1.1.240,255.255.255.0,24h # Range of IPs to assign and TTL
 
 domain=pilink # Domain Name for Pi-Link network
 address=/hub.pilink/10.1.1.1  # The aliases for Pi
+
+# Cloudflares's nameservers
+server=1.1.1.1
+server=1.0.0.1

--- a/services/mqtt2prometheus/Dockerfile
+++ b/services/mqtt2prometheus/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:1.16 as builder
+
+COPY . /build/mqtt2prometheus
+WORKDIR /build/mqtt2prometheus
+RUN make static_build TARGET_FILE=/bin/mqtt2prometheus
+
+FROM gcr.io/distroless/static-debian10:nonroot
+COPY --from=builder /bin/mqtt2prometheus /mqtt2prometheus
+CMD ["/mqtt2prometheus"]

--- a/services/mqtt2prometheus/README.md
+++ b/services/mqtt2prometheus/README.md
@@ -1,0 +1,3 @@
+to run exporter: docker run -it -v "$(pwd)/config.yaml:/config.yaml"  -p  9641:9641 ghcr.io/hikhvar/mqtt2prometheus:latest 
+
+source: https://github.com/hikhvar/mqtt2prometheus

--- a/services/mqtt2prometheus/config.yaml
+++ b/services/mqtt2prometheus/config.yaml
@@ -1,0 +1,40 @@
+# Settings for the MQTT Client. Currently only these three are supported
+mqtt:
+  # The MQTT broker to connect to
+  server: tcp://10.0.0.67:1883
+  # Optional: Username and Password for authenticating with the MQTT Server
+  # user: bob
+  # password: happylittleclouds
+  # Optional: for TLS client certificates
+  # ca_cert: certs/AmazonRootCA1.pem
+  # client_cert: certs/xxxxx-certificate.pem.crt
+  # client_key: certs/xxxxx-private.pem.key
+  # Optional: Used to specify ClientID. The default is <hostname>-<pid>
+  # client_id: somedevice
+  # The Topic path to subscribe to. Be aware that you have to specify the wildcard.
+  topic_path: test
+  # Optional: Regular expression to extract the device ID from the topic path. The default regular expression, assumes
+  # that the last "element" of the topic_path is the device id.
+  # The regular expression must contain a named capture group with the name deviceid
+  # For example the expression for tasamota based sensors is "tele/(?P<deviceid>.*)/.*"
+  # device_id_regex: "(.*/)?(?P<deviceid>.*)"
+  # The MQTT QoS level
+  qos: 0
+cache:
+  # Timeout. Each received metric will be presented for this time if no update is send via MQTT.
+  # Set the timeout to -1 to disable the deletion of metrics from the cache. The exporter presents the ingest timestamp
+  # to prometheus.
+  timeout: 24h
+
+metrics:
+    # The name of the metric in prometheus
+  - prom_name: temperature
+    # The name of the metric in a MQTT JSON message
+    mqtt_name: temperature
+    # The prometheus help text for this metric
+    help: DHT22 temperature reading
+    # The prometheus type for this metric. Valid values are: "gauge" and "counter"
+    type: gauge
+    # A map of string to string for constant labels. This labels will be attached to every prometheus metric
+    const_labels:
+      sensor_type: dht22

--- a/services/prometheus/docker-compose.yml
+++ b/services/prometheus/docker-compose.yml
@@ -9,10 +9,3 @@ services:
     - --config.file=/etc/prometheus/prometheus.yml
     volumes:
     - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
-
-  # dnsmasq_exporter:
-  #   image: ricardbejarano/dnsmasq_exporter
-  #   container_name: dnsmasq_exporter
-  #   ports:
-  #     - 9153:9153
-    

--- a/services/prometheus/prometheus.yml
+++ b/services/prometheus/prometheus.yml
@@ -18,7 +18,7 @@ scrape_configs:
     bearer_token: 'ADD_TOKEN_HERE'
     static_configs:
       - targets: ['ADD_PI_IP_HERE:8123']
-      
-  # - job_name: dnsmasq
-  #   static_configs:
-  #     - targets: ['localhost:9153']
+  
+  - job_name: "dnsmasq"
+    static_configs:
+      - targets: ['localhost:9153']   


### PR DESCRIPTION
followed instructions at https://github.com/google/dnsmasq_exporter
created target in prometheus.yml
can run dnsmasq_exporter locally but not in container
set up service locally

i think what needs to happen is that instead of localhost, it needs to point to the container that prometheus is running in, but i'm not sure how to do that