### PR TITLE
Fix DNS and add Exporter

### DIFF
--- a/bin/runDnsExporter.sh
+++ b/bin/runDnsExporter.sh
@@ -1,0 +1,1 @@
+go run /etc/pilink/services/dns_exporter/dnsmasq.go

--- a/bin/runDnsmasqExporter.sh
+++ b/bin/runDnsmasqExporter.sh
@@ -1,1 +1,0 @@
-go run /etc/pilink/services/dnsmasq_exporter/dnsmasq.go

--- a/bin/runDnsmasqExporter.sh
+++ b/bin/runDnsmasqExporter.sh
@@ -1,0 +1,1 @@
+go run /etc/pilink/services/dnsmasq_exporter/dnsmasq.go

--- a/configs/system/dnsmasq.conf
+++ b/configs/system/dnsmasq.conf
@@ -1,5 +1,15 @@
 interface=wlan0 # Interface to lisen for DHCP Requests
   dhcp-range=10.1.1.10,10.1.1.240,255.255.255.0,24h # Range of IPs to assign and TTL
+  dhcp-option=option:router,10.1.1.1
+  dhcp-option=option:dns-server,10.1.1.1
+  dhcp-option=option:netmask,255.255.255.0
 
+# DNS configuration
+port=53
 domain=pilink # Domain Name for Pi-Link network
 address=/hub.pilink/10.1.1.1  # The aliases for Pi
+
+#Prevents packets with malformed domain names and packets with Private IP Range leaving network
+domain-needed
+bogus-priv
+strict-order

--- a/configs/system/resolved.conf
+++ b/configs/system/resolved.conf
@@ -1,0 +1,25 @@
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+#
+# Entries in this file show the compile time defaults.
+# You can change settings by editing this file.
+# Defaults can be restored by simply deleting this file.
+#
+# See resolved.conf(5) for details
+
+[Resolve]
+#DNS=
+#FallbackDNS=
+#Domains=
+#DNSSEC=no
+#DNSOverTLS=no
+#MulticastDNS=no
+#LLMNR=no
+#Cache=no-negative
+DNSStubListener=no
+#ReadEtcHosts=yes
+#ResolveUnicastSingleLabel=no

--- a/playbooks/network/dns_dhcp.yml
+++ b/playbooks/network/dns_dhcp.yml
@@ -46,6 +46,15 @@
         mode: '0644'
         backup: yes
     
+  - name: Copy resolve config file and backup old one
+      copy:
+        src:  ../../configs/system/resolv.conf
+        dest:  /etc/resolv.conf
+        owner: root
+        group: sys
+        mode: '0644'
+        backup: yes
+
     - name: Make sure /var/db folder exists
       file: 
           path: /var/db
@@ -65,7 +74,7 @@
         
     - name: Remove old DNS package
       package:
-        name: ['systemd-resolve']
+        name: ['systemd-resolved']
         state: absent
         update_cache: yes
 
@@ -76,9 +85,10 @@
         masked: no
       with_items:
           - 'dnsmasq'
-          - 'isc-dhcp-server'
 
-    - name: Enable dhcp on boot
-      command: update-rc.d {{item}} enable
+    - name: Disable Existing DNS and make sure dnsmasq is off
+      service:
+        name: "{{ item }}"
+        enabled: false
       with_items:
-          - isc-dhcp-server
+          - 'systemd-resolved'

--- a/services/dns_exporter/dnsmasq.go
+++ b/services/dns_exporter/dnsmasq.go
@@ -1,0 +1,261 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Binary dnsmasq_exporter is a Prometheus exporter for dnsmasq statistics.
+
+// CHANGES MADE: Changed listening IP to 0.0.0.0 from localhost
+
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/miekg/dns"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/prometheus/common/log"
+	"github.com/prometheus/common/version"
+)
+
+var (
+	listen = flag.String("listen",
+		"0.0.0.0:9153",
+		"listen address")
+
+	leasesPath = flag.String("leases_path",
+		"/var/lib/misc/dnsmasq.leases",
+		"path to the dnsmasq leases file")
+
+	dnsmasqAddr = flag.String("dnsmasq",
+		"localhost:53",
+		"dnsmasq host:port address")
+	metricsPath = flag.String("metrics_path",
+		"/metrics",
+		"path under which metrics are served")
+)
+
+var (
+	// floatMetrics contains prometheus Gauges, keyed by the stats DNS record
+	// they correspond to.
+	floatMetrics = map[string]prometheus.Gauge{
+		"cachesize.bind.": prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "dnsmasq_cachesize",
+			Help: "configured size of the DNS cache",
+		}),
+
+		"insertions.bind.": prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "dnsmasq_insertions",
+			Help: "DNS cache insertions",
+		}),
+
+		"evictions.bind.": prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "dnsmasq_evictions",
+			Help: "DNS cache exictions: numbers of entries which replaced an unexpired cache entry",
+		}),
+
+		"misses.bind.": prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "dnsmasq_misses",
+			Help: "DNS cache misses: queries which had to be forwarded",
+		}),
+
+		"hits.bind.": prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "dnsmasq_hits",
+			Help: "DNS queries answered locally (cache hits)",
+		}),
+
+		"auth.bind.": prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "dnsmasq_auth",
+			Help: "DNS queries for authoritative zones",
+		}),
+	}
+
+	serversMetrics = map[string]*prometheus.GaugeVec{
+		"queries": prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "dnsmasq_servers_queries",
+				Help: "DNS queries on upstream server",
+			},
+			[]string{"server"},
+		),
+		"queries_failed": prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "dnsmasq_servers_queries_failed",
+				Help: "DNS queries failed on upstream server",
+			},
+			[]string{"server"},
+		),
+	}
+
+	leases = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "dnsmasq_leases",
+		Help: "Number of DHCP leases handed out",
+	})
+)
+
+func init() {
+	for _, g := range floatMetrics {
+		prometheus.MustRegister(g)
+	}
+	for _, g := range serversMetrics {
+		prometheus.MustRegister(g)
+	}
+	prometheus.MustRegister(leases)
+	prometheus.MustRegister(version.NewCollector("dnsmasq_exporter"))
+}
+
+// From https://manpages.debian.org/stretch/dnsmasq-base/dnsmasq.8.en.html:
+// The cache statistics are also available in the DNS as answers to queries of
+// class CHAOS and type TXT in domain bind. The domain names are cachesize.bind,
+// insertions.bind, evictions.bind, misses.bind, hits.bind, auth.bind and
+// servers.bind. An example command to query this, using the dig utility would
+// be:
+//     dig +short chaos txt cachesize.bind
+
+type server struct {
+	promHandler http.Handler
+	dnsClient   *dns.Client
+	dnsmasqAddr string
+	leasesPath  string
+}
+
+func question(name string) dns.Question {
+	return dns.Question{
+		Name:   name,
+		Qtype:  dns.TypeTXT,
+		Qclass: dns.ClassCHAOS,
+	}
+}
+
+func (s *server) metrics(w http.ResponseWriter, r *http.Request) {
+	var eg errgroup.Group
+
+	eg.Go(func() error {
+		msg := &dns.Msg{
+			MsgHdr: dns.MsgHdr{
+				Id:               dns.Id(),
+				RecursionDesired: true,
+			},
+			Question: []dns.Question{
+				question("cachesize.bind."),
+				question("insertions.bind."),
+				question("evictions.bind."),
+				question("misses.bind."),
+				question("hits.bind."),
+				question("auth.bind."),
+				question("servers.bind."),
+			},
+		}
+		in, _, err := s.dnsClient.Exchange(msg, s.dnsmasqAddr)
+		if err != nil {
+			return err
+		}
+		for _, a := range in.Answer {
+			txt, ok := a.(*dns.TXT)
+			if !ok {
+				continue
+			}
+			switch txt.Hdr.Name {
+			case "servers.bind.":
+				for _, str := range txt.Txt {
+					arr := strings.Fields(str)
+					if got, want := len(arr), 3; got != want {
+						return fmt.Errorf("stats DNS record servers.bind.: unexpeced number of argument in record: got %d, want %d", got, want)
+					}
+					queries, err := strconv.ParseFloat(arr[1], 64)
+					if err != nil {
+						return err
+					}
+					failedQueries, err := strconv.ParseFloat(arr[2], 64)
+					if err != nil {
+						return err
+					}
+					serversMetrics["queries"].WithLabelValues(arr[0]).Set(queries)
+					serversMetrics["queries_failed"].WithLabelValues(arr[0]).Set(failedQueries)
+				}
+			default:
+				g, ok := floatMetrics[txt.Hdr.Name]
+				if !ok {
+					continue // ignore unexpected answer from dnsmasq
+				}
+				if got, want := len(txt.Txt), 1; got != want {
+					return fmt.Errorf("stats DNS record %q: unexpected number of replies: got %d, want %d", txt.Hdr.Name, got, want)
+				}
+				f, err := strconv.ParseFloat(txt.Txt[0], 64)
+				if err != nil {
+					return err
+				}
+				g.Set(f)
+			}
+		}
+		return nil
+	})
+
+	eg.Go(func() error {
+		f, err := os.Open(s.leasesPath)
+		if err != nil {
+			log.Warnln("could not open leases file:", err)
+			return err
+		}
+		defer f.Close()
+		scanner := bufio.NewScanner(f)
+		var lines float64
+		for scanner.Scan() {
+			lines++
+		}
+		if err := scanner.Err(); err != nil {
+			return err
+		}
+		leases.Set(lines)
+		return nil
+	})
+
+	if err := eg.Wait(); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	s.promHandler.ServeHTTP(w, r)
+}
+
+func main() {
+	flag.Parse()
+	s := &server{
+		promHandler: promhttp.Handler(),
+		dnsClient: &dns.Client{
+			SingleInflight: true,
+		},
+		dnsmasqAddr: *dnsmasqAddr,
+		leasesPath:  *leasesPath,
+	}
+	http.HandleFunc(*metricsPath, s.metrics)
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`<html>
+			<head><title>Dnsmasq Exporter</title></head>
+			<body>
+			<h1>Dnsmasq Exporter</h1>
+			<p><a href="` + *metricsPath + `">Metrics</a></p>
+			</body></html>`))
+	})
+	log.Infoln("Listening on", *listen)
+	log.Infoln("Serving metrics under", *metricsPath)
+	log.Fatal(http.ListenAndServe(*listen, nil))
+}


### PR DESCRIPTION
## PR Overview

- Fixes DNSMasq 
   - adds proper settings, disables isc-dhcp, disable systemd dns stub resolver
- Fixes DNSmasq Exporter
     - Original Google one wasn't meant for containerized prometheus 